### PR TITLE
Moderate up to 3 randomly selected images

### DIFF
--- a/strategies/openai.ts
+++ b/strategies/openai.ts
@@ -13,21 +13,6 @@ const openai = new OpenAI({
 
 const MODEL = "omni-moderation-latest";
 
-const getMultiModalInput = (
-  record: typeof schema.records.$inferSelect,
-): OpenAI.Moderations.ModerationMultiModalInput[] => {
-  return [
-    {
-      type: "text",
-      text: record.text,
-    },
-    ...(record.imageUrls ?? []).map((url) => ({
-      type: "image_url" as const,
-      image_url: { url },
-    })),
-  ];
-};
-
 const reasons = {
   harassment: "Content expresses, incites, or promotes harassing language towards any target",
   "harassment/threatening": "Harassment content that also includes violence or serious harm towards any target",
@@ -76,7 +61,7 @@ export class Strategy implements StrategyInstance {
 
     const moderation = await openai.moderations.create({
       model: MODEL,
-      input: getMultiModalInput(context.record),
+      input: context.record.text,
     });
 
     const result = moderation.results[0];

--- a/strategies/prompt.ts
+++ b/strategies/prompt.ts
@@ -6,6 +6,7 @@ import * as schema from "@/db/schema";
 import { StrategyInstance } from "./types";
 import { LinkData, Context, StrategyResult } from "@/services/moderations";
 import { env } from "@/lib/env";
+import sampleSize from "lodash/sampleSize";
 
 const openai = new OpenAI({
   apiKey: env.OPENAI_API_KEY,
@@ -17,17 +18,16 @@ const getMultiModalInput = (
   record: typeof schema.records.$inferSelect,
   skipImages?: boolean,
 ): OpenAI.Chat.Completions.ChatCompletionContentPart[] => {
+  const images = skipImages ? [] : sampleSize(record.imageUrls, 3);
   return [
     {
-      type: "text",
+      type: "text" as const,
       text: record.text,
     },
-    ...(!skipImages
-      ? record.imageUrls.map((url) => ({
-          type: "image_url" as const,
-          image_url: { url },
-        }))
-      : []),
+    ...images.map((url) => ({
+      type: "image_url" as const,
+      image_url: { url },
+    })),
   ];
 };
 


### PR DESCRIPTION
Change `getMultiModalInput` to return up to 3 randomly selected images.

(Remove image moderation completely from legacy OpenAI Moderation strategy.)