### PR TITLE
Fix webhook timestamps

### DIFF
--- a/inngest/functions/moderations.ts
+++ b/inngest/functions/moderations.ts
@@ -126,24 +126,15 @@ const sendModerationWebhook = inngest.createFunction(
         event: eventType,
         data: {
           id: moderation.id,
-          timestamp: moderation.updatedAt,
-          via: moderation.via,
           payload: {
             id: record.id,
             clientId: record.clientId,
             clientUrl: record.clientUrl ?? undefined,
-            status: moderation.status,
             name: record.name,
             entity: record.entity,
-            user: user
-              ? {
-                  id: user.id,
-                  clientId: user.clientId,
-                  clientUrl: user.clientUrl ?? undefined,
-                  status: user.actionStatus ?? undefined,
-                  protected: true,
-                }
-              : undefined,
+            status: moderation.status,
+            statusUpdatedAt: new Date(moderation.updatedAt).getTime().toString(),
+            statusUpdatedVia: moderation.via,
           },
         },
       });

--- a/inngest/functions/user-actions.ts
+++ b/inngest/functions/user-actions.ts
@@ -111,14 +111,14 @@ const sendUserActionWebhook = inngest.createFunction(
         event: eventType,
         data: {
           id: userAction.id,
-          timestamp: userAction.createdAt,
-          via: userAction.via,
           payload: {
             id: user.id,
-            status: userAction.status,
             clientId: user.clientId,
             clientUrl: user.clientUrl ?? undefined,
             protected: user.protected,
+            status: userAction.status,
+            statusUpdatedAt: new Date(userAction.createdAt).getTime().toString(),
+            statusUpdatedVia: userAction.via,
           },
         },
       });

--- a/services/webhook.ts
+++ b/services/webhook.ts
@@ -10,30 +10,29 @@ type PublicUser = {
   id: string;
   clientId: string;
   clientUrl?: string;
-  status?: (typeof schema.userActionStatus.enumValues)[number];
   protected: boolean;
+  status?: (typeof schema.userActionStatus.enumValues)[number];
+  statusUpdatedAt?: string;
+  statusUpdatedVia?: (typeof schema.via.enumValues)[number];
 };
 
 type PublicRecord = {
   id: string;
   clientId: string;
   clientUrl?: string;
-  status?: (typeof schema.moderationStatus.enumValues)[number];
   name: string;
   entity: string;
-  user?: PublicUser;
+  status?: (typeof schema.moderationStatus.enumValues)[number];
+  statusUpdatedAt?: string;
+  statusUpdatedVia?: (typeof schema.via.enumValues)[number];
 };
 
 type PublicModeration = {
   id: string;
-  timestamp: string;
-  via: (typeof schema.via.enumValues)[number];
 };
 
 type PublicUserAction = {
   id: string;
-  timestamp: string;
-  via: (typeof schema.via.enumValues)[number];
 };
 
 export type WebhookEvents = {
@@ -108,7 +107,8 @@ export async function sendWebhook<T extends keyof WebhookEvents>({
 
   webhook.secret = decrypt(webhook.secret);
 
-  const body = JSON.stringify({ event, ...data });
+  const timestamp = Date.now().toString();
+  const body = JSON.stringify({ event, timestamp, ...data });
   const signature = crypto.createHmac("sha256", webhook.secret).update(body).digest("hex");
 
   try {


### PR DESCRIPTION
This restores the usage of `timestamp` to represent the time the webhook was sent. (Gumroad relies on this timestamp to ensure that delivery was within 1 minute of sending.)

This makes a minor break with backwards compatibility: we no longer send `user: {  protected: boolean }` with the `record.flagged` webhook. We don't have any knowledge of this field being used. (Removing it simplifies the API.)

### `record.flagged` & `record.compliant`

```ts
id: string;
timestamp: string;
payload: {
  id: string;
  clientId: string;
  clientUrl?: string;
  name: string;
  entity: string;
  status?: "Flagged" | "Compliant";
  statusUpdatedAt?: string;
  statusUpdatedVia?:  "AI" | "Automation" | "Manual";;
}
```

### `user.suspended`, `user.banned`, & `user.compliant`

```ts
id: string;
timestamp: string;
payload: {
  id: string;
  clientId: string;
  clientUrl?: string;
  protected: boolean;
  status?: "Suspended" | "Banned" | "Compliant";
  statusUpdatedAt?: string;
  statusUpdatedVia?:  "AI" | "Automation" | "Manual";;
}
```