### PR TITLE
Revert "fix pointer events error with radix DropdownMenuPrimitive (#7)"

### DIFF
--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -6,12 +6,7 @@ import { Check, ChevronRight, Circle } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
-const DropdownMenu = ({ children, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) => (
-  <DropdownMenuPrimitive.Root modal={false} {...props}>
-    {children}
-  </DropdownMenuPrimitive.Root>
-);
-DropdownMenu.displayName = DropdownMenuPrimitive.Root.displayName;
+const DropdownMenu = DropdownMenuPrimitive.Root;
 
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
 


### PR DESCRIPTION
This fix was not a root-cause fix. The actual fix has to do with deduping nested `@radix-ui` packages in the [anti-work/iffy-cloud](https://github.com/anti-work/iffy-cloud) monorepo.

This reverts commit 10160c67ebaabd5dbc163d51e6899eeece1e8134.