### PR TITLE
Add Metadata API

### DIFF
--- a/app/api/v1/ingest/route.ts
+++ b/app/api/v1/ingest/route.ts
@@ -1,6 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import type { ZodSchema } from "zod";
-import { fromZodError } from "zod-validation-error";
 
 import { IngestDeleteRequestData, ingestUpdateAdapter, IngestUpdateRequestData } from "./schema";
 import db from "@/db";
@@ -8,6 +6,7 @@ import * as schema from "@/db/schema";
 import { eq, and } from "drizzle-orm";
 import { validateApiKey } from "@/services/api-keys";
 import { createPendingModeration } from "@/services/moderations";
+import { createOrUpdateUser } from "@/services/users";
 import { createOrUpdateRecord, deleteRecord } from "@/services/records";
 import { inngest } from "@/inngest/client";
 import { parseRequestDataWithSchema } from "@/app/api/parse";
@@ -30,30 +29,17 @@ export async function POST(req: NextRequest) {
 
   let user: typeof schema.users.$inferSelect | undefined;
   if (data.user) {
-    [user] = await db
-      .insert(schema.users)
-      .values({
-        clerkOrganizationId,
-        clientId: data.user.clientId,
-        clientUrl: data.user.clientUrl,
-        email: data.user.email,
-        name: data.user.name,
-        username: data.user.username,
-        protected: data.user.protected,
-        stripeAccountId: data.user.stripeAccountId,
-      })
-      .onConflictDoUpdate({
-        target: schema.users.clientId,
-        set: {
-          clientUrl: data.user.clientUrl,
-          email: data.user.email,
-          name: data.user.name,
-          username: data.user.username,
-          protected: data.user.protected,
-          stripeAccountId: data.user.stripeAccountId,
-        },
-      })
-      .returning();
+    user = await createOrUpdateUser({
+      clerkOrganizationId,
+      clientId: data.user.clientId,
+      clientUrl: data.user.clientUrl,
+      email: data.user.email,
+      name: data.user.name,
+      username: data.user.username,
+      protected: data.user.protected,
+      stripeAccountId: data.user.stripeAccountId,
+      metadata: data.user.metadata,
+    });
   }
 
   const content = typeof data.content === "string" ? { text: data.content } : data.content;
@@ -68,6 +54,7 @@ export async function POST(req: NextRequest) {
     externalUrls: content.externalUrls,
     clientUrl: data.clientUrl,
     userId: user?.id,
+    metadata: data.metadata,
   });
 
   const organizationSettings = await db.query.organizationSettings.findFirst({
@@ -91,8 +78,9 @@ export async function POST(req: NextRequest) {
     moderationThreshold = true;
   }
 
+  let pendingModeration: typeof schema.moderations.$inferSelect | undefined;
   if (moderationThreshold) {
-    const pendingModeration = await createPendingModeration({
+    pendingModeration = await createPendingModeration({
       clerkOrganizationId,
       recordId: record.id,
       via: "AI",
@@ -111,7 +99,7 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  return NextResponse.json({ message: "Success" }, { status: 200 });
+  return NextResponse.json({ moderationId: pendingModeration?.id ?? null, message: "Success" }, { status: 200 });
 }
 
 export async function DELETE(req: NextRequest) {

--- a/app/api/v1/ingest/route.ts
+++ b/app/api/v1/ingest/route.ts
@@ -99,7 +99,15 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  return NextResponse.json({ moderationId: pendingModeration?.id ?? null, message: "Success" }, { status: 200 });
+  return NextResponse.json(
+    {
+      id: record.id,
+      moderation: pendingModeration?.id ?? null,
+      ...(user ? { user: user.id } : {}),
+      message: "Success",
+    },
+    { status: 200 },
+  );
 }
 
 export async function DELETE(req: NextRequest) {

--- a/app/api/v1/ingest/schema.ts
+++ b/app/api/v1/ingest/schema.ts
@@ -1,4 +1,10 @@
 import { z } from "zod";
+import { isValidMetadata } from "@/services/metadata";
+
+const MetadataSchema = z.record(z.string(), z.unknown()).refine(isValidMetadata, {
+  message:
+    "Metadata keys can't be more than 40 characters or include '[' or ']'. Metadata values must be serializable and can't be more than 500 characters. The total number of keys can't be more than 50.",
+});
 
 export const IngestUpdateRequestData = z
   .object({
@@ -14,6 +20,7 @@ export const IngestUpdateRequestData = z
         externalUrls: z.array(z.string().url()).optional(),
       }),
     ]),
+    metadata: MetadataSchema.optional(),
     user: z
       .object({
         clientId: z.string(),
@@ -23,6 +30,7 @@ export const IngestUpdateRequestData = z
         name: z.string().optional(),
         username: z.string().optional(),
         protected: z.boolean().optional(),
+        metadata: MetadataSchema.optional(),
       })
       .optional(),
   })

--- a/app/api/v1/ingest/user/schema.ts
+++ b/app/api/v1/ingest/user/schema.ts
@@ -1,4 +1,10 @@
+import { isValidMetadata } from "@/services/metadata";
 import { z } from "zod";
+
+const MetadataSchema = z.record(z.string(), z.unknown()).refine(isValidMetadata, {
+  message:
+    "Metadata keys can't be more than 40 characters or include '[' or ']'. Metadata values must be serializable and can't be more than 500 characters. The total number of keys can't be more than 50.",
+});
 
 export const IngestUserRequestData = z
   .object({
@@ -9,6 +15,7 @@ export const IngestUserRequestData = z
     name: z.string().optional(),
     username: z.string().optional(),
     protected: z.boolean().optional(),
+    metadata: MetadataSchema.optional(),
   })
   .strict();
 

--- a/app/api/v1/moderate/route.ts
+++ b/app/api/v1/moderate/route.ts
@@ -1,13 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import type { ZodSchema } from "zod";
-import { fromZodError } from "zod-validation-error";
 
 import { moderateAdapter, ModerateRequestData } from "./schema";
-import db from "@/db";
 import * as schema from "@/db/schema";
 import { validateApiKey } from "@/services/api-keys";
 import { createModeration, moderate } from "@/services/moderations";
 import { createOrUpdateRecord } from "@/services/records";
+import { createOrUpdateUser } from "@/services/users";
 import { parseRequestDataWithSchema } from "@/app/api/parse";
 
 export async function POST(req: NextRequest) {
@@ -28,30 +26,17 @@ export async function POST(req: NextRequest) {
 
   let user: typeof schema.users.$inferSelect | undefined;
   if (data.user) {
-    [user] = await db
-      .insert(schema.users)
-      .values({
-        clerkOrganizationId,
-        clientId: data.user.clientId,
-        clientUrl: data.user.clientUrl,
-        email: data.user.email,
-        name: data.user.name,
-        username: data.user.username,
-        protected: data.user.protected,
-        stripeAccountId: data.user.stripeAccountId,
-      })
-      .onConflictDoUpdate({
-        target: schema.users.clientId,
-        set: {
-          clientUrl: data.user.clientUrl,
-          email: data.user.email,
-          name: data.user.name,
-          username: data.user.username,
-          protected: data.user.protected,
-          stripeAccountId: data.user.stripeAccountId,
-        },
-      })
-      .returning();
+    user = await createOrUpdateUser({
+      clerkOrganizationId,
+      clientId: data.user.clientId,
+      clientUrl: data.user.clientUrl,
+      email: data.user.email,
+      name: data.user.name,
+      username: data.user.username,
+      protected: data.user.protected,
+      stripeAccountId: data.user.stripeAccountId,
+      metadata: data.user.metadata,
+    });
   }
 
   const content = typeof data.content === "string" ? { text: data.content } : data.content;
@@ -65,6 +50,7 @@ export async function POST(req: NextRequest) {
     imageUrls: content.imageUrls,
     clientUrl: data.clientUrl,
     userId: user?.id,
+    metadata: data.metadata,
   });
 
   const result = await moderate({
@@ -72,7 +58,7 @@ export async function POST(req: NextRequest) {
     recordId: record.id,
   });
 
-  await createModeration({
+  const moderation = await createModeration({
     clerkOrganizationId,
     recordId: record.id,
     ...result,
@@ -82,6 +68,8 @@ export async function POST(req: NextRequest) {
   return NextResponse.json(
     {
       status: result.status,
+      moderationId: moderation.id,
+      message: "Success",
       // TODO(s3ththompson): deprecate
       flagged: result.status === "Flagged",
       categoryIds: result.ruleIds,

--- a/app/api/v1/moderate/route.ts
+++ b/app/api/v1/moderate/route.ts
@@ -68,7 +68,9 @@ export async function POST(req: NextRequest) {
   return NextResponse.json(
     {
       status: result.status,
-      moderationId: moderation.id,
+      id: record.id,
+      moderation: moderation.id,
+      ...(user ? { user: user.id } : {}),
       message: "Success",
       // TODO(s3ththompson): deprecate
       flagged: result.status === "Flagged",

--- a/app/api/v1/moderate/schema.ts
+++ b/app/api/v1/moderate/schema.ts
@@ -1,4 +1,10 @@
 import { z } from "zod";
+import { isValidMetadata } from "@/services/metadata";
+
+const MetadataSchema = z.record(z.string(), z.unknown()).refine(isValidMetadata, {
+  message:
+    "Metadata keys can't be more than 40 characters or include '[' or ']'. Metadata values must be serializable and can't be more than 500 characters. The total number of keys can't be more than 50.",
+});
 
 export const ModerateRequestData = z
   .object({
@@ -14,6 +20,7 @@ export const ModerateRequestData = z
         externalUrls: z.array(z.string().url()).optional(),
       }),
     ]),
+    metadata: MetadataSchema.optional(),
     user: z
       .object({
         clientId: z.string(),
@@ -23,6 +30,7 @@ export const ModerateRequestData = z
         name: z.string().optional(),
         username: z.string().optional(),
         protected: z.boolean().optional(),
+        metadata: MetadataSchema.optional(),
       })
       .optional(),
   })

--- a/db/tables.ts
+++ b/db/tables.ts
@@ -269,6 +269,7 @@ export const users = pgTable(
     name: text(),
     username: text(),
     protected: boolean().default(false).notNull(),
+    metadata: jsonb(),
     createdAt: timestamp("created_at", { precision: 3, mode: "date" }).defaultNow().notNull(),
     updatedAt: timestamp("updated_at", { precision: 3, mode: "date" })
       .defaultNow()
@@ -464,6 +465,7 @@ export const records = pgTable(
     text: text().notNull(),
     imageUrls: text("image_urls").array().notNull().default([]),
     externalUrls: text("external_urls").array().notNull().default([]),
+    metadata: jsonb(),
     userId: text("user_id"),
     createdAt: timestamp("created_at", { precision: 3, mode: "date" }).defaultNow().notNull(),
     updatedAt: timestamp("updated_at", { precision: 3, mode: "date" })

--- a/drizzle/0018_nifty_micromacro.sql
+++ b/drizzle/0018_nifty_micromacro.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "records" ADD COLUMN "metadata" jsonb;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "metadata" jsonb;

--- a/drizzle/meta/0018_snapshot.json
+++ b/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,1999 @@
+{
+  "id": "e7d19927-861d-493c-a042-a612e8beecb7",
+  "prevId": "08647145-7190-43dc-9495-d89938d0b469",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key_hash": {
+          "name": "encrypted_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_encrypted_key_hash_key": {
+          "name": "api_keys_encrypted_key_hash_key",
+          "columns": [
+            {
+              "expression": "encrypted_key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_encrypted_key_key": {
+          "name": "api_keys_encrypted_key_key",
+          "columns": [
+            {
+              "expression": "encrypted_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_encrypted_key_unique": {
+          "name": "api_keys_encrypted_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "encrypted_key"
+          ]
+        },
+        "api_keys_encrypted_key_hash_unique": {
+          "name": "api_keys_encrypted_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "encrypted_key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appeal_actions": {
+      "name": "appeal_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appeal_id": {
+          "name": "appeal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "AppealActionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "via": {
+          "name": "via",
+          "type": "Via",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Inbound'"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "appeal_actions_appeal_id_fkey": {
+          "name": "appeal_actions_appeal_id_fkey",
+          "tableFrom": "appeal_actions",
+          "tableTo": "appeals",
+          "columnsFrom": [
+            "appeal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appeals": {
+      "name": "appeals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_action_id": {
+          "name": "user_action_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sort": {
+          "name": "sort",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_status": {
+          "name": "action_status",
+          "type": "AppealActionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_status_created_at": {
+          "name": "action_status_created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appeals_clerk_organization_id_idx": {
+          "name": "appeals_clerk_organization_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appeals_user_action_id_idx": {
+          "name": "appeals_user_action_id_idx",
+          "columns": [
+            {
+              "expression": "user_action_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appeals_user_action_id_key": {
+          "name": "appeals_user_action_id_key",
+          "columns": [
+            {
+              "expression": "user_action_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appeals_sort_key": {
+          "name": "appeals_sort_key",
+          "columns": [
+            {
+              "expression": "sort",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appeals_user_action_id_fkey": {
+          "name": "appeals_user_action_id_fkey",
+          "tableFrom": "appeals",
+          "tableTo": "user_actions",
+          "columnsFrom": [
+            "user_action_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "appeals_user_action_id_unique": {
+          "name": "appeals_user_action_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_action_id"
+          ]
+        },
+        "appeals_sort_unique": {
+          "name": "appeals_sort_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sort"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_templates": {
+      "name": "email_templates",
+      "schema": "",
+      "columns": {
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "EmailTemplateType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "email_templates_pkey": {
+          "name": "email_templates_pkey",
+          "columns": [
+            "clerk_organization_id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_action_id": {
+          "name": "user_action_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_id": {
+          "name": "to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_id": {
+          "name": "from_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "MessageType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "MessageStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appeal_id": {
+          "name": "appeal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sort": {
+          "name": "sort",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "messages_sort_key": {
+          "name": "messages_sort_key",
+          "columns": [
+            {
+              "expression": "sort",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_appeal_id_fkey": {
+          "name": "messages_appeal_id_fkey",
+          "tableFrom": "messages",
+          "tableTo": "appeals",
+          "columnsFrom": [
+            "appeal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "messages_from_id_fkey": {
+          "name": "messages_from_id_fkey",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "from_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "messages_user_action_id_fkey": {
+          "name": "messages_user_action_id_fkey",
+          "tableFrom": "messages",
+          "tableTo": "user_actions",
+          "columnsFrom": [
+            "user_action_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "messages_to_id_fkey": {
+          "name": "messages_to_id_fkey",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "messages_sort_unique": {
+          "name": "messages_sort_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sort"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderations": {
+      "name": "moderations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ModerationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "via": {
+          "name": "via",
+          "type": "Via",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AI'"
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ruleset_id": {
+          "name": "ruleset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_mode": {
+          "name": "test_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "moderations_record_id_idx": {
+          "name": "moderations_record_id_idx",
+          "columns": [
+            {
+              "expression": "record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderations_org_status_idx": {
+          "name": "moderations_org_status_idx",
+          "columns": [
+            {
+              "expression": "clerk_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderations_record_id_fkey": {
+          "name": "moderations_record_id_fkey",
+          "tableFrom": "moderations",
+          "tableTo": "records",
+          "columnsFrom": [
+            "record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "moderations_ruleset_id_fkey": {
+          "name": "moderations_ruleset_id_fkey",
+          "tableFrom": "moderations",
+          "tableTo": "rulesets",
+          "columnsFrom": [
+            "ruleset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderations_to_rules": {
+      "name": "moderations_to_rules",
+      "schema": "",
+      "columns": {
+        "moderation_id": {
+          "name": "moderation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "moderations_to_rules_moderation_id_fkey": {
+          "name": "moderations_to_rules_moderation_id_fkey",
+          "tableFrom": "moderations_to_rules",
+          "tableTo": "moderations",
+          "columnsFrom": [
+            "moderation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "moderations_to_rules_rule_id_fkey": {
+          "name": "moderations_to_rules_rule_id_fkey",
+          "tableFrom": "moderations_to_rules",
+          "tableTo": "rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "moderations_to_rules_moderation_id_rule_id_pk": {
+          "name": "moderations_to_rules_moderation_id_rule_id_pk",
+          "columns": [
+            "moderation_id",
+            "rule_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_settings": {
+      "name": "organization_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emails_enabled": {
+          "name": "emails_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "test_mode_enabled": {
+          "name": "test_mode_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "appeals_enabled": {
+          "name": "appeals_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripe_api_key": {
+          "name": "stripe_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_percentage": {
+          "name": "moderation_percentage",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_settings_clerk_organization_id_key": {
+          "name": "organization_settings_clerk_organization_id_key",
+          "columns": [
+            {
+              "expression": "clerk_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_settings_clerk_organization_id_unique": {
+          "name": "organization_settings_clerk_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.preset_strategies": {
+      "name": "preset_strategies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "StrategyType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preset_id": {
+          "name": "preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "preset_strategies_preset_id_fkey": {
+          "name": "preset_strategies_preset_id_fkey",
+          "tableFrom": "preset_strategies",
+          "tableTo": "presets",
+          "columnsFrom": [
+            "preset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.presets": {
+      "name": "presets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.records": {
+      "name": "records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_url": {
+          "name": "client_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_urls": {
+          "name": "image_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "external_urls": {
+          "name": "external_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sort": {
+          "name": "sort",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_status": {
+          "name": "moderation_status",
+          "type": "ModerationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_status_created_at": {
+          "name": "moderation_status_created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_pending": {
+          "name": "moderation_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "moderation_pending_created_at": {
+          "name": "moderation_pending_created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "records_clerk_organization_id_idx": {
+          "name": "records_clerk_organization_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "records_client_id_key": {
+          "name": "records_client_id_key",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "records_user_id_idx": {
+          "name": "records_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "records_sort_key": {
+          "name": "records_sort_key",
+          "columns": [
+            {
+              "expression": "sort",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "records_user_id_fkey": {
+          "name": "records_user_id_fkey",
+          "tableFrom": "records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "records_client_id_unique": {
+          "name": "records_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        },
+        "records_sort_unique": {
+          "name": "records_sort_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sort"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rule_strategies": {
+      "name": "rule_strategies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "StrategyType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rule_strategies_rule_id_fkey": {
+          "name": "rule_strategies_rule_id_fkey",
+          "tableFrom": "rule_strategies",
+          "tableTo": "rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rules": {
+      "name": "rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preset_id": {
+          "name": "preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ruleset_id": {
+          "name": "ruleset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rules_preset_id_fkey": {
+          "name": "rules_preset_id_fkey",
+          "tableFrom": "rules",
+          "tableTo": "presets",
+          "columnsFrom": [
+            "preset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "rules_ruleset_id_fkey": {
+          "name": "rules_ruleset_id_fkey",
+          "tableFrom": "rules",
+          "tableTo": "rulesets",
+          "columnsFrom": [
+            "ruleset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rulesets": {
+      "name": "rulesets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_actions": {
+      "name": "user_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "UserActionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "via": {
+          "name": "via",
+          "type": "Via",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Automation'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_actions_user_id_idx": {
+          "name": "user_actions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_actions_user_id_fkey": {
+          "name": "user_actions_user_id_fkey",
+          "tableFrom": "user_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_url": {
+          "name": "client_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protected": {
+          "name": "protected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sort": {
+          "name": "sort",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_status": {
+          "name": "action_status",
+          "type": "UserActionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_status_created_at": {
+          "name": "action_status_created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flagged_records_count": {
+          "name": "flagged_records_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "users_clerk_organization_id_idx": {
+          "name": "users_clerk_organization_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_client_id_key": {
+          "name": "users_client_id_key",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_sort_key": {
+          "name": "users_sort_key",
+          "columns": [
+            {
+              "expression": "sort",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_client_id_unique": {
+          "name": "users_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        },
+        "users_sort_unique": {
+          "name": "users_sort_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sort"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_endpoints": {
+      "name": "webhook_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhook_endpoint_id": {
+          "name": "webhook_endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "WebhookEventStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webhook_events_webhook_endpoint_id_fkey": {
+          "name": "webhook_events_webhook_endpoint_id_fkey",
+          "tableFrom": "webhook_events",
+          "tableTo": "webhook_endpoints",
+          "columnsFrom": [
+            "webhook_endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.AppealActionStatus": {
+      "name": "AppealActionStatus",
+      "schema": "public",
+      "values": [
+        "Open",
+        "Rejected",
+        "Approved"
+      ]
+    },
+    "public.EmailTemplateType": {
+      "name": "EmailTemplateType",
+      "schema": "public",
+      "values": [
+        "Suspended",
+        "Compliant",
+        "Banned"
+      ]
+    },
+    "public.MessageStatus": {
+      "name": "MessageStatus",
+      "schema": "public",
+      "values": [
+        "Pending",
+        "Delivered"
+      ]
+    },
+    "public.MessageType": {
+      "name": "MessageType",
+      "schema": "public",
+      "values": [
+        "Outbound",
+        "Inbound"
+      ]
+    },
+    "public.ModerationStatus": {
+      "name": "ModerationStatus",
+      "schema": "public",
+      "values": [
+        "Compliant",
+        "Flagged"
+      ]
+    },
+    "public.StrategyType": {
+      "name": "StrategyType",
+      "schema": "public",
+      "values": [
+        "Blocklist",
+        "OpenAI",
+        "Prompt"
+      ]
+    },
+    "public.UserActionStatus": {
+      "name": "UserActionStatus",
+      "schema": "public",
+      "values": [
+        "Compliant",
+        "Suspended",
+        "Banned"
+      ]
+    },
+    "public.Via": {
+      "name": "Via",
+      "schema": "public",
+      "values": [
+        "Inbound",
+        "Manual",
+        "Automation",
+        "AI"
+      ]
+    },
+    "public.WebhookEventStatus": {
+      "name": "WebhookEventStatus",
+      "schema": "public",
+      "values": [
+        "Pending",
+        "Sent",
+        "Failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.moderations_analytics_daily": {
+      "columns": {
+        "time": {
+          "name": "time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderations": {
+          "name": "moderations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flagged": {
+          "name": "flagged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "\n  SELECT\n    date_trunc('day', \"moderations\".\"created_at\" AT TIME ZONE 'UTC') AS time,\n    \"moderations\".\"clerk_organization_id\" AS clerk_organization_id,\n    COUNT(*)::int AS moderations,\n    COUNT(*) FILTER (WHERE \"moderations\".\"status\" = 'Flagged')::int AS flagged\n  FROM \"moderations\"\n  WHERE \"moderations\".\"created_at\" AT TIME ZONE 'UTC' >= date_trunc('day', now() AT TIME ZONE 'UTC') - INTERVAL '29 days'\n  GROUP BY time, \"moderations\".\"clerk_organization_id\"\n",
+      "name": "moderations_analytics_daily",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": true
+    },
+    "public.moderations_analytics_hourly": {
+      "columns": {
+        "time": {
+          "name": "time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderations": {
+          "name": "moderations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flagged": {
+          "name": "flagged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "\n  SELECT\n    date_trunc('hour', \"moderations\".\"created_at\" AT TIME ZONE 'UTC') AS time,\n    \"moderations\".\"clerk_organization_id\" AS clerk_organization_id,\n    COUNT(*)::int AS moderations,\n    COUNT(*) FILTER (WHERE \"moderations\".\"status\" = 'Flagged')::int AS flagged\n  FROM \"moderations\"\n  WHERE \"moderations\".\"created_at\" AT TIME ZONE 'UTC' >= date_trunc('hour', now() AT TIME ZONE 'UTC') - INTERVAL '23 hours'\n  GROUP BY time, \"moderations\".\"clerk_organization_id\"\n",
+      "name": "moderations_analytics_hourly",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": true
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1738855942103,
       "tag": "0017_foamy_silver_centurion",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1739487886311,
+      "tag": "0018_nifty_micromacro",
+      "breakpoints": true
     }
   ]
 }

--- a/inngest/functions/moderations.ts
+++ b/inngest/functions/moderations.ts
@@ -7,6 +7,7 @@ import { createUserAction } from "@/services/user-actions";
 import * as schema from "@/db/schema";
 import { eq, and } from "drizzle-orm";
 import * as service from "@/services/moderations";
+import { parseMetadata } from "@/services/metadata";
 
 const moderate = inngest.createFunction(
   { id: "moderate" },
@@ -132,6 +133,7 @@ const sendModerationWebhook = inngest.createFunction(
             clientUrl: record.clientUrl ?? undefined,
             name: record.name,
             entity: record.entity,
+            metadata: record.metadata ? parseMetadata(record.metadata) : undefined,
             status: moderation.status,
             statusUpdatedAt: new Date(moderation.updatedAt).getTime().toString(),
             statusUpdatedVia: moderation.via,

--- a/inngest/functions/user-actions.ts
+++ b/inngest/functions/user-actions.ts
@@ -12,6 +12,7 @@ import { getAbsoluteUrl } from "@/lib/url";
 import { createAppealAction } from "@/services/appeal-actions";
 import { eq, and } from "drizzle-orm";
 import { decrypt } from "@/services/encrypt";
+import { parseMetadata } from "@/services/metadata";
 
 const updateStripePaymentsAndPayouts = inngest.createFunction(
   { id: "update-stripe-payments-payouts" },
@@ -116,6 +117,7 @@ const sendUserActionWebhook = inngest.createFunction(
             clientId: user.clientId,
             clientUrl: user.clientUrl ?? undefined,
             protected: user.protected,
+            metadata: user.metadata ? parseMetadata(user.metadata) : undefined,
             status: userAction.status,
             statusUpdatedAt: new Date(userAction.createdAt).getTime().toString(),
             statusUpdatedVia: userAction.via,

--- a/services/metadata.ts
+++ b/services/metadata.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+export const isValidMetadata = (metadata: Record<string, unknown>) => {
+  const keys = Object.keys(metadata);
+  if (keys.length > 50) {
+    return false;
+  }
+  for (const [key, value] of Object.entries(metadata)) {
+    if (key.length == 0 || key.length > 40) {
+      return false;
+    }
+    if (key.includes("[") || key.includes("]")) {
+      return false;
+    }
+    let stringifiedValue: string | undefined;
+    try {
+      stringifiedValue = JSON.stringify(value);
+    } catch (e) {
+      return false;
+    }
+    if (stringifiedValue === undefined) {
+      return false;
+    }
+    if (stringifiedValue.length > 500) {
+      return false;
+    }
+  }
+  return true;
+};
+
+export const parseMetadata = (metadata: unknown) => {
+  try {
+    return z.record(z.string(), z.string()).parse(metadata);
+  } catch (e) {
+    return {};
+  }
+};
+
+export const mergeMetadata = (metadata: unknown, newMetadata: Record<string, unknown>) => {
+  let mergedMetadata: Record<string, string>;
+
+  try {
+    mergedMetadata = parseMetadata(metadata);
+  } catch (e) {
+    mergedMetadata = {};
+  }
+
+  if (Object.keys(newMetadata).length === 0) {
+    return {};
+  }
+
+  for (const [key, value] of Object.entries(newMetadata)) {
+    if (value === "") {
+      delete mergedMetadata[key];
+    } else {
+      mergedMetadata[key] = JSON.stringify(value);
+    }
+  }
+  return mergedMetadata;
+};

--- a/services/records.ts
+++ b/services/records.ts
@@ -3,6 +3,7 @@ import { inngest } from "@/inngest/client";
 import * as schema from "@/db/schema";
 import { eq, and, sql } from "drizzle-orm";
 import { findUrlsInText } from "@/services/url-moderation";
+import { mergeMetadata } from "./metadata";
 
 export async function createOrUpdateRecord({
   clerkOrganizationId,
@@ -15,6 +16,7 @@ export async function createOrUpdateRecord({
   clientUrl,
   userId,
   createdAt,
+  metadata,
 }: {
   clerkOrganizationId: string;
   clientId: string;
@@ -26,14 +28,20 @@ export async function createOrUpdateRecord({
   externalUrls?: string[];
   userId?: string;
   createdAt?: Date;
+  metadata?: Record<string, unknown>;
 }) {
   const record = await db.transaction(async (tx) => {
     const lastRecord = await tx.query.records.findFirst({
       where: and(eq(schema.records.clerkOrganizationId, clerkOrganizationId), eq(schema.records.clientId, clientId)),
       columns: {
         userId: true,
+        metadata: true,
       },
     });
+
+    if (lastRecord && metadata) {
+      metadata = mergeMetadata(lastRecord.metadata, metadata);
+    }
 
     const [record] = await tx
       .insert(schema.records)
@@ -46,18 +54,20 @@ export async function createOrUpdateRecord({
         text,
         imageUrls,
         externalUrls,
+        metadata,
         userId,
         createdAt,
       })
       .onConflictDoUpdate({
         target: schema.records.clientId,
         set: {
+          clientUrl,
           name,
           entity,
           text,
           imageUrls,
           externalUrls,
-          clientUrl,
+          metadata,
           userId,
         },
       })

--- a/services/records.ts
+++ b/services/records.ts
@@ -39,7 +39,7 @@ export async function createOrUpdateRecord({
       },
     });
 
-    if (lastRecord && metadata) {
+    if (metadata && lastRecord?.metadata) {
       metadata = mergeMetadata(lastRecord.metadata, metadata);
     }
 

--- a/services/users.ts
+++ b/services/users.ts
@@ -34,7 +34,7 @@ export async function createOrUpdateUser({
       },
     });
 
-    if (lastUser && metadata) {
+    if (metadata && lastUser?.metadata) {
       metadata = mergeMetadata(lastUser.metadata, metadata);
     }
 

--- a/services/users.ts
+++ b/services/users.ts
@@ -3,6 +3,77 @@
 import db from "@/db";
 import { and, desc, isNull, eq } from "drizzle-orm";
 import * as schema from "@/db/schema";
+import { mergeMetadata } from "./metadata";
+
+export async function createOrUpdateUser({
+  clerkOrganizationId,
+  clientId,
+  clientUrl,
+  email,
+  name,
+  username,
+  protected: _protected,
+  stripeAccountId,
+  metadata,
+}: {
+  clerkOrganizationId: string;
+  clientId: string;
+  clientUrl?: string;
+  email?: string;
+  name?: string;
+  username?: string;
+  protected?: boolean;
+  stripeAccountId?: string;
+  metadata?: Record<string, unknown>;
+}) {
+  const user = await db.transaction(async (tx) => {
+    const lastUser = await tx.query.users.findFirst({
+      where: and(eq(schema.users.clerkOrganizationId, clerkOrganizationId), eq(schema.users.clientId, clientId)),
+      columns: {
+        metadata: true,
+      },
+    });
+
+    if (lastUser && metadata) {
+      metadata = mergeMetadata(lastUser.metadata, metadata);
+    }
+
+    const [user] = await db
+      .insert(schema.users)
+      .values({
+        clerkOrganizationId,
+        clientId,
+        clientUrl,
+        email,
+        name,
+        username,
+        protected: _protected,
+        stripeAccountId,
+        metadata,
+      })
+      .onConflictDoUpdate({
+        target: schema.users.clientId,
+        set: {
+          clientUrl,
+          email,
+          name,
+          username,
+          protected: _protected,
+          stripeAccountId,
+          metadata,
+        },
+      })
+      .returning();
+
+    if (!user) {
+      throw new Error("Failed to create or update user");
+    }
+
+    return user;
+  });
+
+  return user;
+}
 
 export async function getFlaggedRecordsFromUser({
   clerkOrganizationId,

--- a/services/webhook.ts
+++ b/services/webhook.ts
@@ -11,6 +11,7 @@ type PublicUser = {
   clientId: string;
   clientUrl?: string;
   protected: boolean;
+  metadata?: Record<string, string>;
   status?: (typeof schema.userActionStatus.enumValues)[number];
   statusUpdatedAt?: string;
   statusUpdatedVia?: (typeof schema.via.enumValues)[number];
@@ -22,6 +23,7 @@ type PublicRecord = {
   clientUrl?: string;
   name: string;
   entity: string;
+  metadata?: Record<string, string>;
   status?: (typeof schema.moderationStatus.enumValues)[number];
   statusUpdatedAt?: string;
   statusUpdatedVia?: (typeof schema.via.enumValues)[number];


### PR DESCRIPTION
Add ability to associate arbitrary metadata with records and users.

Validate metadata using [Stripe](https://docs.stripe.com/metadata) criteria.

Return metadata with webhook payloads.