### PR TITLE
Re-add user data to webhook payloads for record.flagged and record.compliant

### DIFF
--- a/e2e/api.test.ts
+++ b/e2e/api.test.ts
@@ -126,7 +126,7 @@ shortest(async () => {
   expect(moderationResponse.ok()).toBeTruthy();
 });
 
-shortest("Successfully ingest a user", async ({ page }) => {
+shortest(async ({ page }) => {
   const email = `user_${faker.string.nanoid(3)}@example.com`;
 
   const response = await apiContext!.post(`/api/v1/ingest/user`, {

--- a/inngest/functions/moderations.ts
+++ b/inngest/functions/moderations.ts
@@ -137,6 +137,19 @@ const sendModerationWebhook = inngest.createFunction(
             status: moderation.status,
             statusUpdatedAt: new Date(moderation.updatedAt).getTime().toString(),
             statusUpdatedVia: moderation.via,
+            user: user
+              ? {
+                  id: user.id,
+                  clientId: user.clientId,
+                  clientUrl: user.clientUrl ?? undefined,
+                  protected: user.protected,
+                  metadata: user.metadata ? parseMetadata(user.metadata) : undefined,
+                  status: user.actionStatus ?? undefined,
+                  statusUpdatedAt: user.actionStatusCreatedAt
+                    ? new Date(user.actionStatusCreatedAt).getTime().toString()
+                    : undefined,
+                }
+              : undefined,
           },
         },
       });

--- a/services/webhook.ts
+++ b/services/webhook.ts
@@ -27,6 +27,7 @@ type PublicRecord = {
   status?: (typeof schema.moderationStatus.enumValues)[number];
   statusUpdatedAt?: string;
   statusUpdatedVia?: (typeof schema.via.enumValues)[number];
+  user?: PublicUser;
 };
 
 type PublicModeration = {


### PR DESCRIPTION
Some customers may want to avoid acting on `record.flagged` or `record.compliant` if the user is protected.

This fixes a regression with the Gumroad integration. cc @cnnrmnn 