### PR TITLE
Stripe integration should only pause/unpase payments when user is suspended/marked compliant

### DIFF
--- a/app/dashboard/users/[id]/stripe-account.tsx
+++ b/app/dashboard/users/[id]/stripe-account.tsx
@@ -17,7 +17,7 @@ const StripeAccountPaymentsAndPayouts = async ({
   stripeAccountId: string;
   stripeApiKey: string;
 }) => {
-  const { payments, payouts } = await getPaymentsAndPayouts(stripeApiKey, stripeAccountId);
+  const { payments, payouts, reason } = await getPaymentsAndPayouts(stripeApiKey, stripeAccountId);
 
   return (
     <>
@@ -33,6 +33,14 @@ const StripeAccountPaymentsAndPayouts = async ({
           <Badge variant={payouts ? "success" : "failure"}>{payouts ? "Enabled" : "Disabled"}</Badge>
         </dd>
       </div>
+      {reason && (
+        <div className="grid grid-cols-2 gap-4">
+          <dt className="text-stone-500 dark:text-zinc-500">Disabled Reason</dt>
+          <dd className="flex items-center gap-2 break-words">
+            <CodeInline>{reason}</CodeInline>
+          </dd>
+        </div>
+      )}
     </>
   );
 };

--- a/inngest/functions/user-actions.ts
+++ b/inngest/functions/user-actions.ts
@@ -5,7 +5,7 @@ import * as schema from "@/db/schema";
 import { generateAppealToken } from "@/services/appeals";
 import { createMessage } from "@/services/messages";
 import { sendEmail, renderEmailTemplate } from "@/services/email";
-import { pausePaymentsAndPayouts, resumePaymentsAndPayouts } from "@/services/stripe";
+import { pausePayments, resumePayments } from "@/services/stripe";
 import { findOrCreateOrganizationSettings } from "@/services/organization-settings";
 import { RenderedTemplate } from "@/emails/types";
 import { getAbsoluteUrl } from "@/lib/url";
@@ -47,10 +47,10 @@ const updateStripePaymentsAndPayouts = inngest.createFunction(
         switch (status) {
           case "Suspended":
           case "Banned":
-            await pausePaymentsAndPayouts(decrypt(organizationSettings.stripeApiKey), user.stripeAccountId);
+            await pausePayments(decrypt(organizationSettings.stripeApiKey), user.stripeAccountId);
             break;
           case "Compliant":
-            await resumePaymentsAndPayouts(decrypt(organizationSettings.stripeApiKey), user.stripeAccountId);
+            await resumePayments(decrypt(organizationSettings.stripeApiKey), user.stripeAccountId);
             break;
         }
       }

--- a/services/stripe.ts
+++ b/services/stripe.ts
@@ -11,10 +11,11 @@ export async function getPaymentsAndPayouts(stripeApiKey: string, stripeAccountI
   return {
     payments: account.charges_enabled,
     payouts: account.payouts_enabled,
+    reason: account.requirements?.disabled_reason ?? undefined,
   };
 }
 
-export async function pausePaymentsAndPayouts(stripeApiKey: string, stripeAccountId: string) {
+export async function pausePayments(stripeApiKey: string, stripeAccountId: string) {
   if (!stripeApiKey) {
     throw new Error("Stripe API key not provided");
   }
@@ -24,9 +25,6 @@ export async function pausePaymentsAndPayouts(stripeApiKey: string, stripeAccoun
   await stripe.accounts.update(stripeAccountId, {
     // @ts-ignore preview feature
     risk_controls: {
-      payouts: {
-        pause_requested: true,
-      },
       charges: {
         pause_requested: true,
       },
@@ -34,7 +32,7 @@ export async function pausePaymentsAndPayouts(stripeApiKey: string, stripeAccoun
   });
 }
 
-export async function resumePaymentsAndPayouts(stripeApiKey: string, stripeAccountId: string) {
+export async function resumePayments(stripeApiKey: string, stripeAccountId: string) {
   if (!stripeApiKey) {
     throw new Error("Stripe API key not provided");
   }


### PR DESCRIPTION
### Only pause/unpause payments

This PR updates the Stripe integration for Iffy:

- only pause/unpase **payments** when user is suspended/marked compliant (previously, Iffy paused/unpaused **payments** and **payouts**)

### Surface Stripe reason for paused payments in UI

This PR also adds the Stripe reason for paused payments/payouts to help admins differentiate cases when payments/payouts were paused outside of Iffy for other reasons (e.g. fraud)

<img width="716" alt="Screenshot 2025-02-18 at 3 55 42 PM" src="https://github.com/user-attachments/assets/f82e2571-3127-4c53-9466-59e19ae43c5e" />
