### PR TITLE
fix: uncontrolled input error in new rule modal

### DIFF
--- a/app/dashboard/rules/rule-dialog.tsx
+++ b/app/dashboard/rules/rule-dialog.tsx
@@ -145,7 +145,7 @@ export function RuleDialog({ open, onOpenChange, onSubmit, initialData, presets 
                     <FormItem>
                       <FormLabel>Name</FormLabel>
                       <FormControl>
-                        <Input placeholder="My Rule" {...field} />
+                        <Input placeholder="My Rule" {...field} value={field.value ?? ""} />
                       </FormControl>
                       <FormMessage />
                     </FormItem>


### PR DESCRIPTION
### What

When creating new Rule and typing in name, annoying uncontrolled/controlled error occurred in dev mode. This pr fixes it

<img width="558" alt="Screenshot 2025-02-21 at 05 29 08" src="https://github.com/user-attachments/assets/6d4e0fc2-cd83-492a-87a3-2e4bd7434191" />
