### PR TITLE
feat(api): add GET routes for listing and retrieving records & users

### DIFF
--- a/app/api/v1/ingest/user/route.ts
+++ b/app/api/v1/ingest/user/route.ts
@@ -1,7 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 import { IngestUserRequestData } from "./schema";
-import db from "@/db";
-import * as schema from "@/db/schema";
 import { validateApiKey } from "@/services/api-keys";
 import { parseRequestDataWithSchema } from "@/app/api/parse";
 import { createOrUpdateUser } from "@/services/users";

--- a/app/api/v1/records/[id]/route.ts
+++ b/app/api/v1/records/[id]/route.ts
@@ -5,7 +5,7 @@ import db from "@/db";
 import * as schema from "@/db/schema";
 import { validateApiKey } from "@/services/api-keys";
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const authHeader = req.headers.get("Authorization");
   if (!authHeader || !authHeader.startsWith("Bearer ")) {
     return NextResponse.json({ error: { message: "Invalid API key" } }, { status: 401 });
@@ -16,10 +16,12 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
     return NextResponse.json({ error: { message: "Invalid API key" } }, { status: 401 });
   }
 
+  const { id } = await params;
+
   const record = await db.query.records.findFirst({
     where: and(
       eq(schema.records.clerkOrganizationId, clerkOrganizationId),
-      eq(schema.records.id, params.id),
+      eq(schema.records.id, id),
       isNull(schema.records.deletedAt),
     ),
     columns: {

--- a/app/api/v1/records/[id]/route.ts
+++ b/app/api/v1/records/[id]/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { and, eq, isNull } from "drizzle-orm";
+
+import db from "@/db";
+import * as schema from "@/db/schema";
+import { validateApiKey } from "@/services/api-keys";
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return NextResponse.json({ error: { message: "Invalid API key" } }, { status: 401 });
+  }
+  const apiKey = authHeader.split(" ")[1];
+  const clerkOrganizationId = await validateApiKey(apiKey);
+  if (!clerkOrganizationId) {
+    return NextResponse.json({ error: { message: "Invalid API key" } }, { status: 401 });
+  }
+
+  const record = await db.query.records.findFirst({
+    where: and(
+      eq(schema.records.clerkOrganizationId, clerkOrganizationId),
+      eq(schema.records.id, params.id),
+      isNull(schema.records.deletedAt),
+    ),
+    columns: {
+      id: true,
+      clientId: true,
+      clientUrl: true,
+      name: true,
+      entity: true,
+      metadata: true,
+      createdAt: true,
+      updatedAt: true,
+      moderationStatus: true,
+      moderationStatusCreatedAt: true,
+      moderationPending: true,
+      moderationPendingCreatedAt: true,
+      userId: true,
+    },
+  });
+
+  if (!record) {
+    return NextResponse.json({ error: { message: "Record not found" } }, { status: 404 });
+  }
+
+  const { userId, ...rest } = record;
+  return NextResponse.json({
+    data: {
+      ...rest,
+      user: userId,
+    },
+  });
+}

--- a/app/api/v1/users/[id]/route.ts
+++ b/app/api/v1/users/[id]/route.ts
@@ -5,7 +5,7 @@ import db from "@/db";
 import * as schema from "@/db/schema";
 import { validateApiKey } from "@/services/api-keys";
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const authHeader = req.headers.get("Authorization");
   if (!authHeader || !authHeader.startsWith("Bearer ")) {
     return NextResponse.json({ error: { message: "Invalid API key" } }, { status: 401 });
@@ -16,8 +16,10 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
     return NextResponse.json({ error: { message: "Invalid API key" } }, { status: 401 });
   }
 
+  const { id } = await params;
+
   const user = await db.query.users.findFirst({
-    where: and(eq(schema.users.clerkOrganizationId, clerkOrganizationId), eq(schema.users.id, params.id)),
+    where: and(eq(schema.users.clerkOrganizationId, clerkOrganizationId), eq(schema.users.id, id)),
     columns: {
       id: true,
       clientId: true,

--- a/app/api/v1/users/[id]/route.ts
+++ b/app/api/v1/users/[id]/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+
+import db from "@/db";
+import * as schema from "@/db/schema";
+import { validateApiKey } from "@/services/api-keys";
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return NextResponse.json({ error: { message: "Invalid API key" } }, { status: 401 });
+  }
+  const apiKey = authHeader.split(" ")[1];
+  const clerkOrganizationId = await validateApiKey(apiKey);
+  if (!clerkOrganizationId) {
+    return NextResponse.json({ error: { message: "Invalid API key" } }, { status: 401 });
+  }
+
+  const user = await db.query.users.findFirst({
+    where: and(eq(schema.users.clerkOrganizationId, clerkOrganizationId), eq(schema.users.id, params.id)),
+    columns: {
+      id: true,
+      clientId: true,
+      clientUrl: true,
+      email: true,
+      name: true,
+      username: true,
+      protected: true,
+      metadata: true,
+      createdAt: true,
+      updatedAt: true,
+      actionStatus: true,
+      actionStatusCreatedAt: true,
+    },
+  });
+
+  if (!user) {
+    return NextResponse.json({ error: { message: "User not found" } }, { status: 404 });
+  }
+
+  return NextResponse.json({ data: user });
+}

--- a/app/api/v1/users/route.ts
+++ b/app/api/v1/users/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { and, desc, eq, gt, lt } from "drizzle-orm";
+import { SQL } from "drizzle-orm";
+
+import db from "@/db";
+import * as schema from "@/db/schema";
+import { validateApiKey } from "@/services/api-keys";
+import { parseRequestDataWithSchema } from "@/app/api/parse";
+
+const ListUsersRequestData = z.object({
+  limit: z.coerce.number().min(1).max(100).default(10),
+  starting_after: z.string().optional(),
+  ending_before: z.string().optional(),
+  clientId: z.string().optional(),
+  email: z.string().optional(),
+  status: z.enum(["Compliant", "Suspended", "Banned"]).optional(),
+});
+
+export async function GET(req: NextRequest) {
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return NextResponse.json({ error: { message: "Invalid API key" } }, { status: 401 });
+  }
+  const apiKey = authHeader.split(" ")[1];
+  const clerkOrganizationId = await validateApiKey(apiKey);
+  if (!clerkOrganizationId) {
+    return NextResponse.json({ error: { message: "Invalid API key" } }, { status: 401 });
+  }
+
+  const { data, error } = await parseRequestDataWithSchema(req, ListUsersRequestData);
+  if (error) {
+    return NextResponse.json({ error }, { status: 400 });
+  }
+
+  const { limit, starting_after, ending_before, email, clientId, status } = data as z.infer<
+    typeof ListUsersRequestData
+  >;
+
+  let conditions: SQL<unknown>[] = [eq(schema.users.clerkOrganizationId, clerkOrganizationId)];
+
+  if (email) {
+    conditions.push(eq(schema.users.email, email));
+  }
+
+  if (clientId) {
+    conditions.push(eq(schema.users.clientId, clientId));
+  }
+
+  if (status) {
+    conditions.push(eq(schema.users.actionStatus, status));
+  }
+
+  if (starting_after) {
+    const cursor = await db.query.users.findFirst({
+      where: eq(schema.users.id, starting_after),
+      columns: { sort: true },
+    });
+    if (!cursor) {
+      return NextResponse.json({ error: { message: "Invalid starting_after cursor" } }, { status: 400 });
+    }
+    conditions.push(gt(schema.users.sort, cursor.sort));
+  } else if (ending_before) {
+    const cursor = await db.query.users.findFirst({
+      where: eq(schema.users.id, ending_before),
+      columns: { sort: true },
+    });
+    if (!cursor) {
+      return NextResponse.json({ error: { message: "Invalid ending_before cursor" } }, { status: 400 });
+    }
+    conditions.push(lt(schema.users.sort, cursor.sort));
+  }
+
+  const users = await db
+    .select({
+      id: schema.users.id,
+      clientId: schema.users.clientId,
+      clientUrl: schema.users.clientUrl,
+      email: schema.users.email,
+      name: schema.users.name,
+      username: schema.users.username,
+      protected: schema.users.protected,
+      metadata: schema.users.metadata,
+      createdAt: schema.users.createdAt,
+      updatedAt: schema.users.updatedAt,
+      actionStatus: schema.users.actionStatus,
+      actionStatusCreatedAt: schema.users.actionStatusCreatedAt,
+    })
+    .from(schema.users)
+    .where(and(...conditions))
+    .orderBy(ending_before ? desc(schema.users.sort) : schema.users.sort)
+    .limit(limit + 1);
+
+  const hasMore = users.length > limit;
+  if (hasMore) {
+    users.pop();
+  }
+
+  if (ending_before) {
+    users.reverse();
+  }
+
+  return NextResponse.json({
+    data: users,
+    has_more: hasMore,
+  });
+}

--- a/e2e/visual.test.ts
+++ b/e2e/visual.test.ts
@@ -3,7 +3,7 @@ import { shortest } from "@antiwork/shortest";
 const loginEmail = `shortest+clerk_test@${process.env.MAILOSAUR_SERVER_ID}.mailosaur.net`;
 shortest("Log in", { email: loginEmail });
 
-shortest("Check the Moderations dashboard UI")
+shortest("Check the Dashboard Moderations UI at /dashboard/moderations")
   .expect("Verify sidebar navigation and table headers are present")
   .expect("Confirm table has Record, Status, Via, Entity, and Created At columns")
   .expect("Verify AI appears in the Via column")


### PR DESCRIPTION
## New API Routes


| Method | Route | Description | Parameters |
|---------|--------|-------------|-----------|
| GET | `/v1/records/:id` | Retrieve a record | |
| GET | `/v1/records` | List records | filter by `clientId`, `user`, `entity`,  and `status` |
| GET | `/v1/users/:id` | Retrieve a user | |
| GET | `/v1/users` | List users |  filter by `clientId`, `email`, and `status` |

## Parameters

Parameters allow finding records & users by `clientId`, querying all the records that belong to a given `user`, and filtering by `status`. 

```
// All records
GET /api/v1/records?limit=10

// Only compliant records
GET /api/v1/records?status=compliant

// Only flagged records
GET /api/v1/records?status=flagged

// Combined filters
GET /api/v1/records?status=flagged&entity=comment
GET /api/v1/records?status=compliant&user=user_123

// All users
GET /api/v1/users?limit=10

// Users by status
GET /api/v1/users?status=compliant
GET /api/v1/users?status=suspended
GET /api/v1/users?status=banned

// Combined filters
GET /api/v1/users?status=suspended&email=user@example.com
GET /api/v1/users?status=banned&clientId=client_123
```

## Pagination

Pagination follows Stripe-style pagination with `limit`, `starting_after`, and `ending_before`.

```
// Paginated results with status filter
GET /api/v1/records?limit=10&status=flagged&starting_after=record_456

// Paginated results with status filter
GET /api/v1/users?limit=10&status=suspended&starting_after=user_456
```