### PR TITLE
nit(strategies): Change the inferred types of strategy options to be Zod input types

### DIFF
--- a/app/dashboard/rules/schema.ts
+++ b/app/dashboard/rules/schema.ts
@@ -5,9 +5,12 @@ const strategySchema = z.discriminatedUnion("type", [
     type: z.literal("Blocklist"),
     options: z.object({
       blocklist: z.array(z.string()).refine((value) => value.length > 0, "Blocklist must have at least one word"),
-      matcher: z.object({
-        onlyMatchWords: z.boolean().default(false),
-      }),
+      matcher: z
+        .object({
+          onlyMatchWords: z.boolean().optional().default(false),
+        })
+        .optional()
+        .default({ onlyMatchWords: false }),
     }),
   }),
   z.object({
@@ -15,7 +18,7 @@ const strategySchema = z.discriminatedUnion("type", [
     options: z.object({
       topic: z.string().refine((value) => value !== "", "Topic is required"),
       prompt: z.string().refine((value) => value !== "", "Prompt is required"),
-      skipImages: z.boolean().default(false),
+      skipImages: z.boolean().optional().default(false),
     }),
   }),
   z.object({
@@ -39,5 +42,5 @@ export const ruleFormSchema = z.discriminatedUnion("type", [
   }),
 ]);
 
-export type RuleFormValues = z.infer<typeof ruleFormSchema>;
-export type StrategyFormValues = z.infer<typeof strategySchema>;
+export type RuleFormValues = z.input<typeof ruleFormSchema>;
+export type StrategyFormValues = z.input<typeof strategySchema>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/user-agents": "^1.0.4",
-        "drizzle-kit": "^0.29.0",
+        "drizzle-kit": "^0.30.4",
         "drizzle-seed": "^0.1.3",
         "eslint": "^8.57.0",
         "eslint-config-next": "15.0.0",
@@ -8430,9 +8430,9 @@
       }
     },
     "node_modules/drizzle-kit": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.29.1.tgz",
-      "integrity": "sha512-OvHL8RVyYiPR3LLRE3SHdcON8xGXl+qMfR9uTTnFWBPIqVk/3NWYZPb7nfpM1Bhix3H+BsxqPyyagG7YZ+Z63A==",
+      "version": "0.30.4",
+      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.30.4.tgz",
+      "integrity": "sha512-B2oJN5UkvwwNHscPWXDG5KqAixu7AUzZ3qbe++KU9SsQ+cZWR4DXEPYcvWplyFAno0dhRJECNEhNxiDmFaPGyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/user-agents": "^1.0.4",
-    "drizzle-kit": "^0.29.0",
+    "drizzle-kit": "^0.30.4",
     "drizzle-seed": "^0.1.3",
     "eslint": "^8.57.0",
     "eslint-config-next": "15.0.0",

--- a/strategies/blocklist.ts
+++ b/strategies/blocklist.ts
@@ -120,17 +120,18 @@ export const optionsSchema = z.object({
   blocklist: z.array(z.string()),
   matcher: z
     .object({
-      onlyMatchWords: z.boolean().default(false),
+      onlyMatchWords: z.boolean().optional().default(false),
     })
+    .optional()
     .default({ onlyMatchWords: false }),
 });
 
-export type Options = z.infer<typeof optionsSchema>;
+export type Options = z.input<typeof optionsSchema>;
 
 export class Strategy implements StrategyInstance {
   name = "Blocklist";
 
-  private readonly options: Options;
+  private readonly options: z.infer<typeof optionsSchema>;
 
   constructor(options: unknown) {
     this.options = optionsSchema.parse(options);

--- a/strategies/openai.ts
+++ b/strategies/openai.ts
@@ -40,12 +40,12 @@ export const optionsSchema = z.object({
   thresholds: z.record(z.string(), z.number()),
 });
 
-export type Options = z.infer<typeof optionsSchema>;
+export type Options = z.input<typeof optionsSchema>;
 
 export class Strategy implements StrategyInstance {
   name = "OpenAI Moderation";
 
-  private readonly options: Options;
+  private readonly options: z.infer<typeof optionsSchema>;
 
   constructor(options: unknown) {
     this.options = optionsSchema.parse(options);

--- a/strategies/prompt.ts
+++ b/strategies/prompt.ts
@@ -45,7 +45,7 @@ export const type = "Prompt";
 export const optionsSchema = z.object({
   topic: z.string(),
   prompt: z.string(),
-  skipImages: z.boolean().optional(),
+  skipImages: z.boolean().optional().default(false),
 });
 
 export type Options = z.infer<typeof optionsSchema>;
@@ -53,7 +53,7 @@ export type Options = z.infer<typeof optionsSchema>;
 export class Strategy implements StrategyInstance {
   name = "Prompt";
 
-  private options: Options;
+  private options: z.input<typeof optionsSchema>;
 
   constructor(options: unknown) {
     this.options = optionsSchema.parse(options);

--- a/strategies/prompt.ts
+++ b/strategies/prompt.ts
@@ -48,12 +48,12 @@ export const optionsSchema = z.object({
   skipImages: z.boolean().optional().default(false),
 });
 
-export type Options = z.infer<typeof optionsSchema>;
+export type Options = z.input<typeof optionsSchema>;
 
 export class Strategy implements StrategyInstance {
   name = "Prompt";
 
-  private options: z.input<typeof optionsSchema>;
+  private options: z.infer<typeof optionsSchema>;
 
   constructor(options: unknown) {
     this.options = optionsSchema.parse(options);


### PR DESCRIPTION
This makes the strategy option types:

```ts
{
  string[];
  matcher?: {
    onlyMatchWords?: boolean | undefined;
  } | undefined;
}
```

and

```ts
{
  topic: string;
  prompt: string;
  skipImages?: boolean | undefined;
 }
```

(Note optional keys.)