### PR TITLE
fix(users): Ensure ingest API does not overwrite protected status on update

### DIFF
--- a/app/api/v1/ingest/route.ts
+++ b/app/api/v1/ingest/route.ts
@@ -36,7 +36,7 @@ export async function POST(req: NextRequest) {
       email: data.user.email,
       name: data.user.name,
       username: data.user.username,
-      protected: data.user.protected,
+      initialProtected: data.user.protected,
       stripeAccountId: data.user.stripeAccountId,
       metadata: data.user.metadata,
     });

--- a/app/api/v1/ingest/user/route.ts
+++ b/app/api/v1/ingest/user/route.ts
@@ -27,7 +27,7 @@ export async function POST(req: NextRequest) {
     email: data.email,
     name: data.name,
     username: data.username,
-    protected: data.protected,
+    initialProtected: data.protected,
     stripeAccountId: data.stripeAccountId,
     metadata: data.metadata,
   });

--- a/app/api/v1/moderate/route.ts
+++ b/app/api/v1/moderate/route.ts
@@ -33,7 +33,7 @@ export async function POST(req: NextRequest) {
       email: data.user.email,
       name: data.user.name,
       username: data.user.username,
-      protected: data.user.protected,
+      initialProtected: data.user.protected,
       stripeAccountId: data.user.stripeAccountId,
       metadata: data.user.metadata,
     });

--- a/services/users.ts
+++ b/services/users.ts
@@ -12,7 +12,7 @@ export async function createOrUpdateUser({
   email,
   name,
   username,
-  protected: _protected,
+  initialProtected,
   stripeAccountId,
   metadata,
 }: {
@@ -22,7 +22,7 @@ export async function createOrUpdateUser({
   email?: string;
   name?: string;
   username?: string;
-  protected?: boolean;
+  initialProtected?: boolean;
   stripeAccountId?: string;
   metadata?: Record<string, unknown>;
 }) {
@@ -47,7 +47,7 @@ export async function createOrUpdateUser({
         email,
         name,
         username,
-        protected: _protected,
+        protected: initialProtected,
         stripeAccountId,
         metadata,
       })
@@ -58,7 +58,6 @@ export async function createOrUpdateUser({
           email,
           name,
           username,
-          protected: _protected,
           stripeAccountId,
           metadata,
         },


### PR DESCRIPTION
Iffy should be the source of truth for whether a user is protected or not.

Previously, `/api/v1/ingest` and `/api/v1/ingest/user` set the protected flag when creating a new user *and* when updating an existing user.

The intent of `protected` in `/api/v1/ingest` is to set the *initial* protected status. This PR only sets `protected` when creating a new user.

> Note: After this fix, we will rename the public API parameter (with backwards compatibility) to `initialProtected` for clarity.