### PR TITLE
feat(records): Add the ability to protect / unprotect records

### DIFF
--- a/app/api/v1/ingest/route.ts
+++ b/app/api/v1/ingest/route.ts
@@ -79,7 +79,7 @@ export async function POST(req: NextRequest) {
   }
 
   let pendingModeration: typeof schema.moderations.$inferSelect | undefined;
-  if (moderationThreshold) {
+  if (moderationThreshold && !record.protected) {
     pendingModeration = await createPendingModeration({
       clerkOrganizationId,
       recordId: record.id,

--- a/app/api/v1/moderate/route.ts
+++ b/app/api/v1/moderate/route.ts
@@ -53,6 +53,16 @@ export async function POST(req: NextRequest) {
     metadata: data.metadata,
   });
 
+  if (record.protected) {
+    return NextResponse.json(
+      {
+        id: record.id,
+        message: "Record is protected",
+      },
+      { status: 403 },
+    );
+  }
+
   const result = await moderate({
     clerkOrganizationId,
     recordId: record.id,

--- a/app/api/v1/records/[id]/route.ts
+++ b/app/api/v1/records/[id]/route.ts
@@ -4,6 +4,7 @@ import { and, eq, isNull } from "drizzle-orm";
 import db from "@/db";
 import * as schema from "@/db/schema";
 import { validateApiKey } from "@/services/api-keys";
+import { parseMetadata } from "@/services/metadata";
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const authHeader = req.headers.get("Authorization");
@@ -30,6 +31,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
       clientUrl: true,
       name: true,
       entity: true,
+      protected: true,
       metadata: true,
       createdAt: true,
       updatedAt: true,
@@ -45,11 +47,12 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     return NextResponse.json({ error: { message: "Record not found" } }, { status: 404 });
   }
 
-  const { userId, ...rest } = record;
+  const { userId, metadata, ...rest } = record;
   return NextResponse.json({
     data: {
       ...rest,
       user: userId,
+      metadata: metadata ? parseMetadata(metadata) : undefined,
     },
   });
 }

--- a/app/api/v1/records/route.ts
+++ b/app/api/v1/records/route.ts
@@ -7,6 +7,7 @@ import db from "@/db";
 import * as schema from "@/db/schema";
 import { validateApiKey } from "@/services/api-keys";
 import { parseRequestDataWithSchema } from "@/app/api/parse";
+import { parseMetadata } from "@/services/metadata";
 
 const ListRecordsRequestData = z.object({
   limit: z.coerce.number().min(1).max(100).default(10),
@@ -93,6 +94,7 @@ export async function GET(req: NextRequest) {
       clientUrl: schema.records.clientUrl,
       name: schema.records.name,
       entity: schema.records.entity,
+      protected: schema.records.protected,
       metadata: schema.records.metadata,
       createdAt: schema.records.createdAt,
       updatedAt: schema.records.updatedAt,
@@ -117,9 +119,10 @@ export async function GET(req: NextRequest) {
   }
 
   return NextResponse.json({
-    data: records.map(({ userId, ...record }) => ({
+    data: records.map(({ userId, metadata, ...record }) => ({
       ...record,
       user: userId,
+      metadata: metadata ? parseMetadata(metadata) : undefined,
     })),
     has_more: hasMore,
   });

--- a/app/dashboard/moderations/columns.tsx
+++ b/app/dashboard/moderations/columns.tsx
@@ -9,7 +9,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { formatRecordStatus, formatRecordVia } from "@/lib/badges";
 import { ActionMenu } from "../records/action-menu";
 import type { Record } from "../records/types";
-import { FlaskConical } from "lucide-react";
+import { FlaskConical, ShieldCheck } from "lucide-react";
 import { Date } from "@/components/date";
 
 const columnHelper = createColumnHelper<Record>();
@@ -46,18 +46,34 @@ export const columns = [
       return (
         <div className="flex w-64 items-center space-x-1 truncate">
           <span className="w-full truncate font-bold">{props.getValue()}</span>
-          {row.original.moderations[0]?.testMode && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger>
-                  <FlaskConical size={16} className="text-stone-500 dark:text-zinc-500" />
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>Test Mode</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          )}
+          <span>
+            {row.original.protected && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <ShieldCheck size={16} className="text-stone-500 dark:text-zinc-500" />
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Protected</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+          </span>
+          <span>
+            {row.original.moderations[0]?.testMode && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <FlaskConical size={16} className="text-stone-500 dark:text-zinc-500" />
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Test Mode</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+          </span>
         </div>
       );
     },

--- a/app/dashboard/records/[id]/record.tsx
+++ b/app/dashboard/records/[id]/record.tsx
@@ -1,6 +1,6 @@
 import { Separator } from "@/components/ui/separator";
 import { formatModerationStatus, formatRecordStatus, formatUserStatus, formatVia } from "@/lib/badges";
-import { ExternalLink, FlaskConical, FlaskConicalOff } from "lucide-react";
+import { ExternalLink, FlaskConical, FlaskConicalOff, ShieldCheck, ShieldOff } from "lucide-react";
 import { RecordImages } from "./record-images";
 import { Code, CodeInline } from "@/components/code";
 import { Header, HeaderContent, HeaderPrimary, HeaderSecondary, HeaderActions } from "@/components/sheet/header";
@@ -55,6 +55,29 @@ export async function RecordDetail({ clerkOrganizationId, id }: { clerkOrganizat
           <HeaderSecondary>{record.entity}</HeaderSecondary>
         </HeaderContent>
         <HeaderActions className="flex items-center gap-4">
+          {record.protected ? (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger>
+                  <ShieldCheck className="h-4 w-4 text-stone-500 dark:text-zinc-500" />
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Protected</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger>
+                  <ShieldOff className="h-4 w-4 text-stone-300 dark:text-zinc-500" />
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Not Protected</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
           {record.moderations[0]?.testMode ? (
             <TooltipProvider>
               <Tooltip>
@@ -62,7 +85,7 @@ export async function RecordDetail({ clerkOrganizationId, id }: { clerkOrganizat
                   <FlaskConical className="h-4 w-4 text-stone-500 dark:text-zinc-500" />
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>Test Mode</p>
+                  <p>Test Mode On</p>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>

--- a/app/dashboard/users/[id]/record-user.tsx
+++ b/app/dashboard/users/[id]/record-user.tsx
@@ -55,7 +55,7 @@ export async function UserDetail({ clerkOrganizationId, id }: { clerkOrganizatio
                   <ShieldCheck className="h-4 w-4 text-stone-500 dark:text-zinc-500" />
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>Protected User</p>
+                  <p>Protected</p>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
@@ -66,7 +66,7 @@ export async function UserDetail({ clerkOrganizationId, id }: { clerkOrganizatio
                   <ShieldOff className="h-4 w-4 text-stone-300 dark:text-zinc-500" />
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>Test Mode</p>
+                  <p>Not Protected</p>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>

--- a/app/dashboard/users/columns.tsx
+++ b/app/dashboard/users/columns.tsx
@@ -48,18 +48,20 @@ export const columns = [
       return (
         <div className="flex w-64 items-center space-x-1 truncate">
           <span className="w-full truncate font-bold">{props.getValue()}</span>
-          {row.original.protected && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger>
-                  <ShieldCheck size={16} className="text-stone-500 dark:text-zinc-500" />
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>Protected User</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          )}
+          <span>
+            {row.original.protected && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <ShieldCheck size={16} className="text-stone-500 dark:text-zinc-500" />
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Protected User</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+          </span>
         </div>
       );
     },

--- a/db/seed/record-users.ts
+++ b/db/seed/record-users.ts
@@ -19,7 +19,7 @@ export async function seedUsers(clerkOrganizationId: string) {
           name: faker.person.fullName({ firstName, lastName }),
           username: faker.internet.userName({ firstName, lastName }).toLocaleLowerCase(),
           createdAt: faker.date.recent({ days: 10 }),
-          protected: sample([true, false]),
+          protected: sample([true, false, false, false, false]),
         };
       }),
     )

--- a/db/seed/records.ts
+++ b/db/seed/records.ts
@@ -76,6 +76,7 @@ export async function seedRecords(
           text: faker.lorem.paragraph(),
           userId: sample(users)?.id,
           createdAt: faker.date.recent({ days: 10 }),
+          protected: sample([true, false, false, false, false]),
         };
       }),
     )
@@ -93,7 +94,7 @@ export async function seedRecords(
       .insert(schema.moderations)
       .values({
         clerkOrganizationId,
-        status: isFlagged ? "Flagged" : "Compliant",
+        status: isFlagged && !record.protected ? "Flagged" : "Compliant",
         reasoning: faker.lorem.paragraph(2),
         recordId: record.id,
         rulesetId: ruleset.id,

--- a/db/tables.ts
+++ b/db/tables.ts
@@ -466,6 +466,7 @@ export const records = pgTable(
     text: text().notNull(),
     imageUrls: text("image_urls").array().notNull().default([]),
     externalUrls: text("external_urls").array().notNull().default([]),
+    protected: boolean("protected").default(false).notNull(),
     metadata: jsonb(),
     userId: text("user_id"),
     createdAt: timestamp("created_at", { precision: 3, mode: "date" }).defaultNow().notNull(),

--- a/drizzle/0020_slimy_starjammers.sql
+++ b/drizzle/0020_slimy_starjammers.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "records" ADD COLUMN "protected" boolean DEFAULT false NOT NULL;

--- a/drizzle/meta/0020_snapshot.json
+++ b/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,2012 @@
+{
+  "id": "7c924930-c87d-4f46-9c47-39350f59e5fa",
+  "prevId": "96fd147d-f007-4c07-b4f3-510acd0eb82f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key_hash": {
+          "name": "encrypted_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_encrypted_key_hash_key": {
+          "name": "api_keys_encrypted_key_hash_key",
+          "columns": [
+            {
+              "expression": "encrypted_key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_encrypted_key_key": {
+          "name": "api_keys_encrypted_key_key",
+          "columns": [
+            {
+              "expression": "encrypted_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_encrypted_key_unique": {
+          "name": "api_keys_encrypted_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "encrypted_key"
+          ]
+        },
+        "api_keys_encrypted_key_hash_unique": {
+          "name": "api_keys_encrypted_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "encrypted_key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appeal_actions": {
+      "name": "appeal_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appeal_id": {
+          "name": "appeal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "AppealActionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "via": {
+          "name": "via",
+          "type": "Via",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Inbound'"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "appeal_actions_appeal_id_fkey": {
+          "name": "appeal_actions_appeal_id_fkey",
+          "tableFrom": "appeal_actions",
+          "tableTo": "appeals",
+          "columnsFrom": [
+            "appeal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appeals": {
+      "name": "appeals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_action_id": {
+          "name": "user_action_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sort": {
+          "name": "sort",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_status": {
+          "name": "action_status",
+          "type": "AppealActionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_status_created_at": {
+          "name": "action_status_created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appeals_clerk_organization_id_idx": {
+          "name": "appeals_clerk_organization_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appeals_user_action_id_idx": {
+          "name": "appeals_user_action_id_idx",
+          "columns": [
+            {
+              "expression": "user_action_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appeals_user_action_id_key": {
+          "name": "appeals_user_action_id_key",
+          "columns": [
+            {
+              "expression": "user_action_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appeals_sort_key": {
+          "name": "appeals_sort_key",
+          "columns": [
+            {
+              "expression": "sort",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appeals_user_action_id_fkey": {
+          "name": "appeals_user_action_id_fkey",
+          "tableFrom": "appeals",
+          "tableTo": "user_actions",
+          "columnsFrom": [
+            "user_action_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "appeals_user_action_id_unique": {
+          "name": "appeals_user_action_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_action_id"
+          ]
+        },
+        "appeals_sort_unique": {
+          "name": "appeals_sort_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sort"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_templates": {
+      "name": "email_templates",
+      "schema": "",
+      "columns": {
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "EmailTemplateType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "email_templates_pkey": {
+          "name": "email_templates_pkey",
+          "columns": [
+            "clerk_organization_id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_action_id": {
+          "name": "user_action_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_id": {
+          "name": "to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_id": {
+          "name": "from_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "MessageType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "MessageStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appeal_id": {
+          "name": "appeal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sort": {
+          "name": "sort",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "messages_sort_key": {
+          "name": "messages_sort_key",
+          "columns": [
+            {
+              "expression": "sort",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_appeal_id_fkey": {
+          "name": "messages_appeal_id_fkey",
+          "tableFrom": "messages",
+          "tableTo": "appeals",
+          "columnsFrom": [
+            "appeal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "messages_from_id_fkey": {
+          "name": "messages_from_id_fkey",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "from_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "messages_user_action_id_fkey": {
+          "name": "messages_user_action_id_fkey",
+          "tableFrom": "messages",
+          "tableTo": "user_actions",
+          "columnsFrom": [
+            "user_action_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "messages_to_id_fkey": {
+          "name": "messages_to_id_fkey",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "messages_sort_unique": {
+          "name": "messages_sort_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sort"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderations": {
+      "name": "moderations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ModerationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "via": {
+          "name": "via",
+          "type": "Via",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AI'"
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ruleset_id": {
+          "name": "ruleset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_mode": {
+          "name": "test_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "moderations_record_id_idx": {
+          "name": "moderations_record_id_idx",
+          "columns": [
+            {
+              "expression": "record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderations_org_status_idx": {
+          "name": "moderations_org_status_idx",
+          "columns": [
+            {
+              "expression": "clerk_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderations_record_id_fkey": {
+          "name": "moderations_record_id_fkey",
+          "tableFrom": "moderations",
+          "tableTo": "records",
+          "columnsFrom": [
+            "record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "moderations_ruleset_id_fkey": {
+          "name": "moderations_ruleset_id_fkey",
+          "tableFrom": "moderations",
+          "tableTo": "rulesets",
+          "columnsFrom": [
+            "ruleset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderations_to_rules": {
+      "name": "moderations_to_rules",
+      "schema": "",
+      "columns": {
+        "moderation_id": {
+          "name": "moderation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "moderations_to_rules_moderation_id_fkey": {
+          "name": "moderations_to_rules_moderation_id_fkey",
+          "tableFrom": "moderations_to_rules",
+          "tableTo": "moderations",
+          "columnsFrom": [
+            "moderation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "moderations_to_rules_rule_id_fkey": {
+          "name": "moderations_to_rules_rule_id_fkey",
+          "tableFrom": "moderations_to_rules",
+          "tableTo": "rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "moderations_to_rules_moderation_id_rule_id_pk": {
+          "name": "moderations_to_rules_moderation_id_rule_id_pk",
+          "columns": [
+            "moderation_id",
+            "rule_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_settings": {
+      "name": "organization_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emails_enabled": {
+          "name": "emails_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "test_mode_enabled": {
+          "name": "test_mode_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "appeals_enabled": {
+          "name": "appeals_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripe_api_key": {
+          "name": "stripe_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_percentage": {
+          "name": "moderation_percentage",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_settings_clerk_organization_id_key": {
+          "name": "organization_settings_clerk_organization_id_key",
+          "columns": [
+            {
+              "expression": "clerk_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_settings_clerk_organization_id_unique": {
+          "name": "organization_settings_clerk_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.preset_strategies": {
+      "name": "preset_strategies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "StrategyType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preset_id": {
+          "name": "preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "preset_strategies_preset_id_fkey": {
+          "name": "preset_strategies_preset_id_fkey",
+          "tableFrom": "preset_strategies",
+          "tableTo": "presets",
+          "columnsFrom": [
+            "preset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.presets": {
+      "name": "presets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.records": {
+      "name": "records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_url": {
+          "name": "client_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_urls": {
+          "name": "image_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "external_urls": {
+          "name": "external_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "protected": {
+          "name": "protected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sort": {
+          "name": "sort",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_status": {
+          "name": "moderation_status",
+          "type": "ModerationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_status_created_at": {
+          "name": "moderation_status_created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_pending": {
+          "name": "moderation_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "moderation_pending_created_at": {
+          "name": "moderation_pending_created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "records_clerk_organization_id_idx": {
+          "name": "records_clerk_organization_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "records_client_id_key": {
+          "name": "records_client_id_key",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "records_user_id_idx": {
+          "name": "records_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "records_sort_key": {
+          "name": "records_sort_key",
+          "columns": [
+            {
+              "expression": "sort",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "records_user_id_fkey": {
+          "name": "records_user_id_fkey",
+          "tableFrom": "records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "records_client_id_unique": {
+          "name": "records_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        },
+        "records_sort_unique": {
+          "name": "records_sort_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sort"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rule_strategies": {
+      "name": "rule_strategies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "StrategyType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rule_strategies_rule_id_fkey": {
+          "name": "rule_strategies_rule_id_fkey",
+          "tableFrom": "rule_strategies",
+          "tableTo": "rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rules": {
+      "name": "rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preset_id": {
+          "name": "preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ruleset_id": {
+          "name": "ruleset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rules_preset_id_fkey": {
+          "name": "rules_preset_id_fkey",
+          "tableFrom": "rules",
+          "tableTo": "presets",
+          "columnsFrom": [
+            "preset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "rules_ruleset_id_fkey": {
+          "name": "rules_ruleset_id_fkey",
+          "tableFrom": "rules",
+          "tableTo": "rulesets",
+          "columnsFrom": [
+            "ruleset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rulesets": {
+      "name": "rulesets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_actions": {
+      "name": "user_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "UserActionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "via": {
+          "name": "via",
+          "type": "Via",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Automation'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_actions_user_id_idx": {
+          "name": "user_actions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_actions_user_id_fkey": {
+          "name": "user_actions_user_id_fkey",
+          "tableFrom": "user_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_url": {
+          "name": "client_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protected": {
+          "name": "protected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sort": {
+          "name": "sort",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_status": {
+          "name": "action_status",
+          "type": "UserActionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_status_created_at": {
+          "name": "action_status_created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flagged_records_count": {
+          "name": "flagged_records_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "users_clerk_organization_id_idx": {
+          "name": "users_clerk_organization_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_client_id_key": {
+          "name": "users_client_id_key",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_sort_key": {
+          "name": "users_sort_key",
+          "columns": [
+            {
+              "expression": "sort",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_client_id_unique": {
+          "name": "users_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        },
+        "users_sort_unique": {
+          "name": "users_sort_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sort"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_endpoints": {
+      "name": "webhook_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhook_endpoint_id": {
+          "name": "webhook_endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "WebhookEventStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webhook_events_webhook_endpoint_id_fkey": {
+          "name": "webhook_events_webhook_endpoint_id_fkey",
+          "tableFrom": "webhook_events",
+          "tableTo": "webhook_endpoints",
+          "columnsFrom": [
+            "webhook_endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.AppealActionStatus": {
+      "name": "AppealActionStatus",
+      "schema": "public",
+      "values": [
+        "Open",
+        "Rejected",
+        "Approved"
+      ]
+    },
+    "public.EmailTemplateType": {
+      "name": "EmailTemplateType",
+      "schema": "public",
+      "values": [
+        "Suspended",
+        "Compliant",
+        "Banned"
+      ]
+    },
+    "public.MessageStatus": {
+      "name": "MessageStatus",
+      "schema": "public",
+      "values": [
+        "Pending",
+        "Delivered"
+      ]
+    },
+    "public.MessageType": {
+      "name": "MessageType",
+      "schema": "public",
+      "values": [
+        "Outbound",
+        "Inbound"
+      ]
+    },
+    "public.ModerationStatus": {
+      "name": "ModerationStatus",
+      "schema": "public",
+      "values": [
+        "Compliant",
+        "Flagged"
+      ]
+    },
+    "public.StrategyType": {
+      "name": "StrategyType",
+      "schema": "public",
+      "values": [
+        "Blocklist",
+        "OpenAI",
+        "Prompt"
+      ]
+    },
+    "public.UserActionStatus": {
+      "name": "UserActionStatus",
+      "schema": "public",
+      "values": [
+        "Compliant",
+        "Suspended",
+        "Banned"
+      ]
+    },
+    "public.Via": {
+      "name": "Via",
+      "schema": "public",
+      "values": [
+        "Inbound",
+        "Manual",
+        "Automation",
+        "AI"
+      ]
+    },
+    "public.WebhookEventStatus": {
+      "name": "WebhookEventStatus",
+      "schema": "public",
+      "values": [
+        "Pending",
+        "Sent",
+        "Failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.moderations_analytics_daily": {
+      "columns": {
+        "time": {
+          "name": "time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderations": {
+          "name": "moderations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flagged": {
+          "name": "flagged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "\n  SELECT\n    date_trunc('day', \"moderations\".\"created_at\" AT TIME ZONE 'UTC') AS time,\n    \"moderations\".\"clerk_organization_id\" AS clerk_organization_id,\n    COUNT(*)::int AS moderations,\n    COUNT(*) FILTER (WHERE \"moderations\".\"status\" = 'Flagged')::int AS flagged\n  FROM \"moderations\"\n  WHERE \"moderations\".\"created_at\" AT TIME ZONE 'UTC' >= date_trunc('day', now() AT TIME ZONE 'UTC') - INTERVAL '29 days'\n  GROUP BY time, \"moderations\".\"clerk_organization_id\"\n",
+      "name": "moderations_analytics_daily",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": true
+    },
+    "public.moderations_analytics_hourly": {
+      "columns": {
+        "time": {
+          "name": "time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_organization_id": {
+          "name": "clerk_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderations": {
+          "name": "moderations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flagged": {
+          "name": "flagged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "\n  SELECT\n    date_trunc('hour', \"moderations\".\"created_at\" AT TIME ZONE 'UTC') AS time,\n    \"moderations\".\"clerk_organization_id\" AS clerk_organization_id,\n    COUNT(*)::int AS moderations,\n    COUNT(*) FILTER (WHERE \"moderations\".\"status\" = 'Flagged')::int AS flagged\n  FROM \"moderations\"\n  WHERE \"moderations\".\"created_at\" AT TIME ZONE 'UTC' >= date_trunc('hour', now() AT TIME ZONE 'UTC') - INTERVAL '23 hours'\n  GROUP BY time, \"moderations\".\"clerk_organization_id\"\n",
+      "name": "moderations_analytics_hourly",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": true
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1740182349143,
       "tag": "0019_cool_forgotten_one",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1740580485002,
+      "tag": "0020_slimy_starjammers",
+      "breakpoints": true
     }
   ]
 }

--- a/inngest/functions/moderations.ts
+++ b/inngest/functions/moderations.ts
@@ -133,6 +133,7 @@ const sendModerationWebhook = inngest.createFunction(
             clientUrl: record.clientUrl ?? undefined,
             name: record.name,
             entity: record.entity,
+            protected: record.protected,
             metadata: record.metadata ? parseMetadata(record.metadata) : undefined,
             status: moderation.status,
             statusUpdatedAt: new Date(moderation.updatedAt).getTime().toString(),

--- a/services/records.ts
+++ b/services/records.ts
@@ -16,6 +16,7 @@ export async function createOrUpdateRecord({
   clientUrl,
   userId,
   createdAt,
+  initialProtected,
   metadata,
 }: {
   clerkOrganizationId: string;
@@ -28,6 +29,7 @@ export async function createOrUpdateRecord({
   externalUrls?: string[];
   userId?: string;
   createdAt?: Date;
+  initialProtected?: boolean;
   metadata?: Record<string, unknown>;
 }) {
   const record = await db.transaction(async (tx) => {
@@ -54,6 +56,7 @@ export async function createOrUpdateRecord({
         text,
         imageUrls,
         externalUrls,
+        protected: initialProtected,
         metadata,
         userId,
         createdAt,

--- a/services/webhook.ts
+++ b/services/webhook.ts
@@ -23,6 +23,7 @@ type PublicRecord = {
   clientUrl?: string;
   name: string;
   entity: string;
+  protected: boolean;
   metadata?: Record<string, string>;
   status?: (typeof schema.moderationStatus.enumValues)[number];
   statusUpdatedAt?: string;


### PR DESCRIPTION
### What

This feature allows admins to mark certain records as "protected" (just as with users). If a record is protected, it cannot be manually flagged, or automatically re-moderated.

#### API behavior

When a new version of a protected record is ingested with `/api/v1/ingest`, the API returns 200 but does not moderate.

When a new version of a protected record is moderated with the (deprecated) `/api/v1/moderate`, the API returns 403 with "Record is protected." message.

#### Seeded records

This PR also adds some protected records to the seeded records for testing.

### Why

In some cases, the admin may want to ensure that a subsequent automatic / AI moderation does not undo a manual moderation.

### Screenshot

<img width="714" alt="Screenshot 2025-02-26 at 12 05 52 PM" src="https://github.com/user-attachments/assets/1eb619fb-9048-400d-a3c2-5fce5e74ceb7" />

> Note: This migration may need to be run outside of CI in production.