### PR TITLE
fix(api): Separate request body and query param parsing

### DIFF
--- a/app/api/v1/ingest/route.ts
+++ b/app/api/v1/ingest/route.ts
@@ -9,7 +9,7 @@ import { createPendingModeration } from "@/services/moderations";
 import { createOrUpdateUser } from "@/services/users";
 import { createOrUpdateRecord, deleteRecord } from "@/services/records";
 import { inngest } from "@/inngest/client";
-import { parseRequestDataWithSchema } from "@/app/api/parse";
+import { parseRequestBody } from "@/app/api/parse";
 
 export async function POST(req: NextRequest) {
   const authHeader = req.headers.get("Authorization");
@@ -22,7 +22,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: { message: "Invalid API key" } }, { status: 401 });
   }
 
-  const { data, error } = await parseRequestDataWithSchema(req, IngestUpdateRequestData, ingestUpdateAdapter);
+  const { data, error } = await parseRequestBody(req, IngestUpdateRequestData, ingestUpdateAdapter);
   if (error) {
     return NextResponse.json({ error }, { status: 400 });
   }
@@ -121,7 +121,7 @@ export async function DELETE(req: NextRequest) {
     return NextResponse.json({ error: { message: "Invalid API key" } }, { status: 401 });
   }
 
-  const { data, error } = await parseRequestDataWithSchema(req, IngestDeleteRequestData);
+  const { data, error } = await parseRequestBody(req, IngestDeleteRequestData);
   if (error) {
     return NextResponse.json({ error }, { status: 400 });
   }

--- a/app/api/v1/ingest/user/route.ts
+++ b/app/api/v1/ingest/user/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { IngestUserRequestData } from "./schema";
 import { validateApiKey } from "@/services/api-keys";
-import { parseRequestDataWithSchema } from "@/app/api/parse";
+import { parseRequestBody } from "@/app/api/parse";
 import { createOrUpdateUser } from "@/services/users";
 
 export async function POST(req: NextRequest) {
@@ -15,7 +15,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: { message: "Invalid API key" } }, { status: 401 });
   }
 
-  const { data, error } = await parseRequestDataWithSchema(req, IngestUserRequestData);
+  const { data, error } = await parseRequestBody(req, IngestUserRequestData);
   if (error) {
     return NextResponse.json({ error }, { status: 400 });
   }

--- a/app/api/v1/moderate/route.ts
+++ b/app/api/v1/moderate/route.ts
@@ -6,10 +6,10 @@ import { validateApiKey } from "@/services/api-keys";
 import { createModeration, moderate } from "@/services/moderations";
 import { createOrUpdateRecord } from "@/services/records";
 import { createOrUpdateUser } from "@/services/users";
-import { parseRequestDataWithSchema } from "@/app/api/parse";
+import { parseRequestBody } from "@/app/api/parse";
 
 export async function POST(req: NextRequest) {
-  const { data, error } = await parseRequestDataWithSchema(req, ModerateRequestData, moderateAdapter);
+  const { data, error } = await parseRequestBody(req, ModerateRequestData, moderateAdapter);
   if (error) {
     return NextResponse.json({ error }, { status: 400 });
   }

--- a/app/api/v1/records/route.ts
+++ b/app/api/v1/records/route.ts
@@ -6,7 +6,7 @@ import { SQL } from "drizzle-orm";
 import db from "@/db";
 import * as schema from "@/db/schema";
 import { validateApiKey } from "@/services/api-keys";
-import { parseRequestDataWithSchema } from "@/app/api/parse";
+import { parseQueryParams } from "@/app/api/parse";
 import { parseMetadata } from "@/services/metadata";
 
 const ListRecordsRequestData = z.object({
@@ -30,14 +30,12 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: { message: "Invalid API key" } }, { status: 401 });
   }
 
-  const { data, error } = await parseRequestDataWithSchema(req, ListRecordsRequestData);
+  const { data, error } = await parseQueryParams(req, ListRecordsRequestData);
   if (error) {
     return NextResponse.json({ error }, { status: 400 });
   }
 
-  const { limit, starting_after, ending_before, user, entity, clientId, status } = data as z.infer<
-    typeof ListRecordsRequestData
-  >;
+  const { limit, starting_after, ending_before, user, entity, clientId, status } = data;
 
   let conditions: SQL<unknown>[] = [
     eq(schema.records.clerkOrganizationId, clerkOrganizationId),

--- a/app/api/v1/users/route.ts
+++ b/app/api/v1/users/route.ts
@@ -6,7 +6,7 @@ import { SQL } from "drizzle-orm";
 import db from "@/db";
 import * as schema from "@/db/schema";
 import { validateApiKey } from "@/services/api-keys";
-import { parseRequestDataWithSchema } from "@/app/api/parse";
+import { parseQueryParams } from "@/app/api/parse";
 import { findOrCreateOrganizationSettings } from "@/services/organization-settings";
 import { getAbsoluteUrl } from "@/lib/url";
 import { generateAppealToken } from "@/services/appeals";
@@ -32,16 +32,14 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: { message: "Invalid API key" } }, { status: 401 });
   }
 
-  const { data, error } = await parseRequestDataWithSchema(req, ListUsersRequestData);
+  const { data, error } = await parseQueryParams(req, ListUsersRequestData);
   if (error) {
     return NextResponse.json({ error }, { status: 400 });
   }
 
   const organizationSettings = await findOrCreateOrganizationSettings(clerkOrganizationId);
 
-  const { limit, starting_after, ending_before, email, clientId, status, user } = data as z.infer<
-    typeof ListUsersRequestData
-  >;
+  const { limit, starting_after, ending_before, email, clientId, status, user } = data;
 
   let conditions: SQL<unknown>[] = [eq(schema.users.clerkOrganizationId, clerkOrganizationId)];
 


### PR DESCRIPTION
- Separate request body parsing (for `POST` requests) from query param parsing (for `GET` requests)
- Distinguish between Zod input schemas and output schemas (to ensure default values are propagated to return types correctly)