### PR TITLE
feat(users,records): Add user-supplied Metadata to UI

### DIFF
--- a/app/dashboard/@sheet/(.)users/[userId]/page.tsx
+++ b/app/dashboard/@sheet/(.)users/[userId]/page.tsx
@@ -1,5 +1,5 @@
 import { auth } from "@clerk/nextjs/server";
-import { UserDetail } from "@/app/dashboard/users/[userId]/record-user";
+import { UserDetail } from "@/app/dashboard/users/[userId]/user";
 import { notFound, redirect } from "next/navigation";
 import { RouterSheet } from "@/components/router-sheet";
 import db from "@/db";

--- a/app/dashboard/records/[recordId]/record.tsx
+++ b/app/dashboard/records/[recordId]/record.tsx
@@ -18,6 +18,7 @@ import { CopyButton } from "@/components/copy-button";
 import * as schema from "@/db/schema";
 import { eq, desc, and } from "drizzle-orm";
 import db from "@/db";
+import { parseMetadata } from "@/services/metadata";
 
 export async function RecordDetail({ clerkOrganizationId, id }: { clerkOrganizationId: string; id: string }) {
   const record = await db.query.records.findFirst({
@@ -44,6 +45,8 @@ export async function RecordDetail({ clerkOrganizationId, id }: { clerkOrganizat
   if (!record) {
     return null;
   }
+
+  const metadata = record.metadata ? parseMetadata(record.metadata) : undefined;
 
   const rules = record.moderations[0]?.moderationsToRules.map((moderationToRule) => moderationToRule.rule);
 
@@ -163,6 +166,26 @@ export async function RecordDetail({ clerkOrganizationId, id }: { clerkOrganizat
           </dl>
         </SectionContent>
       </Section>
+      {metadata && (
+        <>
+          <Separator className="my-2" />
+          <Section>
+            <SectionTitle>Metadata</SectionTitle>
+            <SectionContent>
+              <dl className="grid gap-3">
+                {Object.entries(metadata).map(([key, value]) => (
+                  <div key={key} className="grid grid-cols-2 gap-4">
+                    <dt className="font-mono text-stone-500 dark:text-zinc-500">{key}</dt>
+                    <dd>
+                      <CodeInline>{value}</CodeInline>
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </SectionContent>
+          </Section>
+        </>
+      )}
       <Separator className="my-2" />
       <Section>
         <SectionTitle>Content</SectionTitle>

--- a/app/dashboard/users/[userId]/page.tsx
+++ b/app/dashboard/users/[userId]/page.tsx
@@ -1,5 +1,5 @@
 import { auth } from "@clerk/nextjs/server";
-import { UserDetail } from "./record-user";
+import { UserDetail } from "./user";
 import { notFound, redirect } from "next/navigation";
 import { Metadata } from "next";
 import db from "@/db";

--- a/app/dashboard/users/[userId]/user.tsx
+++ b/app/dashboard/users/[userId]/user.tsx
@@ -18,6 +18,7 @@ import { CopyButton } from "@/components/copy-button";
 import { eq, and, desc } from "drizzle-orm";
 import { StripeAccount } from "./stripe-account";
 import { notFound } from "next/navigation";
+import { parseMetadata } from "@/services/metadata";
 
 export async function UserDetail({ clerkOrganizationId, id }: { clerkOrganizationId: string; id: string }) {
   const user = await db.query.users.findFirst({
@@ -35,6 +36,8 @@ export async function UserDetail({ clerkOrganizationId, id }: { clerkOrganizatio
   if (!user) {
     return notFound();
   }
+
+  const metadata = user.metadata ? parseMetadata(user.metadata) : undefined;
 
   return (
     <div>
@@ -118,6 +121,26 @@ export async function UserDetail({ clerkOrganizationId, id }: { clerkOrganizatio
         <>
           <Separator className="my-2" />
           <StripeAccount clerkOrganizationId={clerkOrganizationId} stripeAccountId={user.stripeAccountId} />
+        </>
+      )}
+      {metadata && (
+        <>
+          <Separator className="my-2" />
+          <Section>
+            <SectionTitle>Metadata</SectionTitle>
+            <SectionContent>
+              <dl className="grid gap-3">
+                {Object.entries(metadata).map(([key, value]) => (
+                  <div key={key} className="grid grid-cols-2 gap-4">
+                    <dt className="font-mono text-stone-500 dark:text-zinc-500">{key}</dt>
+                    <dd>
+                      <CodeInline>{value}</CodeInline>
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </SectionContent>
+          </Section>
         </>
       )}
       {user.actions.length > 0 && (

--- a/db/seed/record-users.ts
+++ b/db/seed/record-users.ts
@@ -18,6 +18,9 @@ export async function seedUsers(clerkOrganizationId: string) {
           email: faker.internet.email({ firstName, lastName }).toLocaleLowerCase(),
           name: faker.person.fullName({ firstName, lastName }),
           username: faker.internet.userName({ firstName, lastName }).toLocaleLowerCase(),
+          metadata: {
+            totalSales: faker.commerce.price({ max: 1000 }),
+          },
           createdAt: faker.date.recent({ days: 10 }),
           protected: sample([true, false, false, false, false]),
         };

--- a/db/seed/records.ts
+++ b/db/seed/records.ts
@@ -74,6 +74,10 @@ export async function seedRecords(
           name: product.name,
           entity: "Product",
           text: faker.lorem.paragraph(),
+          metadata: {
+            price: faker.commerce.price({ max: 20 }),
+            material: faker.commerce.productMaterial(),
+          },
           userId: sample(users)?.id,
           createdAt: faker.date.recent({ days: 10 }),
           protected: sample([true, false, false, false, false]),


### PR DESCRIPTION
### What

- Display user-supplied Metadata in the UI for records and users.
- Add user-supplied metadata values to the seed data

### Screenshot

<img width="638" alt="Screenshot 2025-03-01 at 6 46 54 PM" src="https://github.com/user-attachments/assets/90f0c981-0320-4c1a-aef1-7f6ab340ac79" />
